### PR TITLE
Refactor: Optmize docker image with alpine and multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use the official Go image as the base image
-FROM golang:1.22.3
+# 1 - Build Stage
+FROM golang:1.22.3-alpine AS builder
 
 # Set the working directory inside the container
 WORKDIR /app
@@ -13,11 +13,17 @@ RUN go mod download
 # Copy the source code into the container
 COPY . .
 
+# Build the Go application
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o web cmd/rest/main.go
+
+# 2 - Runtime Stage
+FROM scratch
+
+# Copy only the binary from the build stage to the final image
+COPY --from=builder /app/web /
+
 #Expose ports
 EXPOSE 8080
-
-# Build the Go application
-RUN go build -o web cmd/rest/main.go
 
 #Run the web usecases on container startup
 CMD ["./web"]


### PR DESCRIPTION
## Why
A imagem do docker do webserver da aplicação atualmente pesa 1,35GB. Para ambiente de desenvolvimento, seria interessante utilizar uma imagem final mais enxuta, sem as dependências necessárias para a etapa de build da aplicação.

## Pull request type
- [ ] New resource
- [ ] Update resource
- [ ] Bugfix
- [x] Other (please describe):
   - Alterada imagem base para image do Go Alpine;
   - Aplicada estratégia de multi-stage build para manter na imagem final somente o binário da aplicação;
   - O tamanho da imagem final pós refatoração é de 34,4MB.
## Rollback plan
- [x] Revert this PR
- [ ] Other (please, specify):